### PR TITLE
Clarify relationship with JSON-LD

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -40,7 +40,7 @@ The website should advertise a media feed to the user agent by adding a `link` e
 </head>
 ```
 
-Media Feeds should be [valid JSON+LD documents](https://www.w3.org/TR/json-ld11/#dfn-json-ld-document) and contain data using the existing [schema.org](https://schema.org) standard. The user agent will fetch the media feed using a `GET` request with the appropriate cookies, caching headers and the accept header will be set to `application/ld+json`.
+Media Feeds use a subset of [JSON+LD](https://www.w3.org/TR/json-ld11/#dfn-json-ld-document) and contain data using the existing [schema.org](https://schema.org) standard. The user agent will fetch the media feed using a `GET` request with the appropriate cookies, caching headers and the accept header will be set to `application/ld+json`.
 
 ```js
 {

--- a/index.html
+++ b/index.html
@@ -220,9 +220,11 @@
     </p>
 
     <p>
-      The site will return the <dfn>media feed document</dfn> which MUST be a
-      <a data-cite="json-ld11#dfn-json-ld-document">valid JSON+LD</a>
-      document</a>.
+      The site will return the <dfn>media feed document</dfn> which MUST be
+      valid <a data-cite="JSON#">JSON</a>. The feed uses a restricted subset of
+      <a data-cite="json-ld11#">JSON+LD</a> as specified in this spec. This
+      results in the feed being compatible with <a data-cite="json-ld11#">JSON+LD</a>
+      but not the other way around.
     </p>
 
     <p>


### PR DESCRIPTION
This is something that has come up a few times. We don't actually use the full JSON-LD spec but rather a subset.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/media-feeds/pull/35.html" title="Last updated on Jun 5, 2020, 9:11 PM UTC (6582ae0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/media-feeds/35/452debd...6582ae0.html" title="Last updated on Jun 5, 2020, 9:11 PM UTC (6582ae0)">Diff</a>