### PR TITLE
Change link rel type to media-feed

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -32,11 +32,11 @@ Media Feeds provides a way for user agents to discover such feeds and provides a
 
 ## Design
 
-The website should advertise a media feed to the user agent by adding a `link` element to the head of the document. The `rel` attribute should be set to `feed` and the type should be set to `application/ld+json`. The `href` attribute should be on the same origin as the document URL. A user agent will automatically discover the media feed and store it to be fetched later.
+The website should advertise a media feed to the user agent by adding a `link` element to the head of the document. The `rel` attribute should be set to `media-feed`. The `href` attribute should be on the same origin as the document URL. A user agent will automatically discover the media feed and store it to be fetched later.
 
 ```html
 <head>
-  <link rel="feed" type="application/ld+json" href="https://www.example.com/media-feed">
+  <link rel="media-feed" href="https://www.example.com/media-feed">
 </head>
 ```
 

--- a/index.html
+++ b/index.html
@@ -163,14 +163,8 @@
 
       <ul>
         <li>
-          If the <a data-cite="HTML#attr-hyperlink-type">type attribute</a> is
-          not set to
-          <a data-cite="json-ld11#iana-considerations">application/ld+json</a>
-          then return null
-        </li>
-        <li>
           If the <a data-cite="HTML#linkTypes">link type</a> is not set to
-          <code>feed</code> then return null
+          <code>media-feed</code> then return null
         </li>
         <li>
           If the <a>media feed URL</a> is not a valid


### PR DESCRIPTION
In Issue #30 there has been feedback that we should change the <link rel> type to media-feed from feed. There has been some pushback on `rel=media-feed` too although I still think this is our best option since it lines up with our use of `DataFeed` in schema.org and the name of the spec. `rel=suggested-videos` limits us to adding support for other media formats in the future.