### PR TITLE
Update IANA considerations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1435,30 +1435,23 @@
   <section>
     <h2 id="iana">IANA Considerations</h2>
 
-    <h3 id="iana-well-known">Well-known <code>media-feeds</code> URI</h3>
+    <h3 id="iana-link-relations">Link relation type <code>media-feed</code></h3>
 
     <p>
       This section provides the provisional registration of the
-      <dfn><code>media-feeds</code> well-known URI</dfn> in the Well-Known URIs
-      registry in accordance with
-      <a data-cite="RFC8615#">Well-Known Uniform Resource Identifiers (URIs)</a>.
-    </p>
-
-    <p class="note">
-      Although the rest of this specification, and indeed the rest of the web platform,
-      <a href="https://url.spec.whatwg.org/#url-apis-elsewhere">uses the term "URL"</a>,
-      this section in particular intersects with a community that uses the term "URI".
+      <dfn><code>media-feed</code> link relation type</dfn> in the link relation
+      type registry in accordance with <a data-cite="rfc8288#">Web Linking</a>.
     </p>
 
     <dl>
-      <dt><strong>URI suffix</strong></dt>
-      <dd><code>media-feeds</code></dd>
+      <dt><strong>Relation Name</strong></dt>
+      <dd><code>media-feed</code></dd>
 
-      <dt><strong>Change controller</strong></dt>
-      <dd><code>WICG</code></dd>
+      <dt><strong>Description</strong></dt>
+      <dd><code>Refers to a feed of personalised media recommendations relevant to the link context</code></dd>
 
-      <dt><strong>Specification document(s)</strong></dt>
-      <dd><a href="https://wicg.github.io/media-feeds/">https://wicg.github.io/media-feeds/</a></dd>
+      <dt><strong>Reference document(s)</strong></dt>
+      <dd><a href="https://wicg.github.io/media-feeds/#discovery-of-media-feeds">https://wicg.github.io/media-feeds/#discovery-of-media-feeds</a></dd>
 
       <dt><strong>Related information</strong></dt>
       <dd>N/A</dd>


### PR DESCRIPTION
Update the IANA considerations section to remove the old well-known URI and replace it with our link relation registry registration from https://github.com/protocol-registries/link-relations/issues/20