### PR TITLE
Fix broken references for link element and secure context

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
 
     <p>
       The site should advertise the Media Feed to the user agent by adding a
-      <a data-cite="HTML#link">link element</a> to the
+      <a data-cite="HTML#the-link-element">link element</a> to the
       <a data-cite="HTML#the-head-element">head element</a>, these are known as
       the <dfn>eligible feed links</dfn>. The
       <a data-cite="HTML#attr-hyperlink-href">href attribute</a> contains the
@@ -175,7 +175,7 @@
     <p>
       Media Feeds are only discovered on top-level
       <a data-cite="HTML#document">Documents</a> that are a
-      <a data-cite="secure-contexts#secure-context">secure context</a>.
+      <a data-cite="HTML#secure-context">secure context</a>.
     </p>
 
     <p>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/media-feeds/pull/58.html" title="Last updated on Feb 6, 2023, 2:44 AM UTC (18db9b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/media-feeds/58/540aed1...18db9b3.html" title="Last updated on Feb 6, 2023, 2:44 AM UTC (18db9b3)">Diff</a>